### PR TITLE
Add complex expression test with interface inheritance that fails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 obj
 .vscode
+/.vs/*


### PR DESCRIPTION
It seams that the `(notIdIsEmpty || q.Id != notId) && (q.Id == idOrAdditionalId || q.AdditionalIds.Contains(idOrAdditionalId))` problem has to do with the inheritance and interface inheritance in FoxIDs.

I have added a complex expression test with inheritance that works and with interface inheritance that fails. The interface inheritance that fails is the problem in FoxIds. Do you think it is possible to resolve the interface inheritance problem?
